### PR TITLE
Allow filtering taxonomies

### DIFF
--- a/src/Controller/Single.php
+++ b/src/Controller/Single.php
@@ -53,12 +53,12 @@ class Single extends Base {
 	 * @return void
 	 */
 	protected function set_terms( $post_type_object ) {
-		$taxonomies = $post_type_object->taxonomies;
+		$taxonomies = get_object_taxonomies( $post_type_object->name );
 		if ( ! $taxonomies ) {
 			return;
 		}
 
-		$taxonomy = array_shift( $taxonomies );
+		$taxonomy = apply_filters( 'inc2734_wp_breadcrumbs_main_taxonomy', array_shift( $taxonomies ), $taxonomies, $post_type_object->name );
 		$terms    = get_the_terms( get_the_ID(), $taxonomy );
 
 		if ( ! $terms ) {

--- a/src/Controller/Single.php
+++ b/src/Controller/Single.php
@@ -58,7 +58,7 @@ class Single extends Base {
 			return;
 		}
 
-		$taxonomy = apply_filters( 'inc2734_wp_breadcrumbs_main_taxonomy', array_shift( $taxonomies ), $taxonomies, $post_type_object->name );
+		$taxonomy = apply_filters( 'inc2734_wp_breadcrumbs_main_taxonomy', array_shift( $taxonomies ), $taxonomies, $post_type_object );
 		$terms    = get_the_terms( get_the_ID(), $taxonomy );
 
 		if ( ! $terms ) {


### PR DESCRIPTION
Thanks for this good library!

This PR fixes some things. 

`$post_type_object->taxonomies` does not necessarily return all attached taxonomies. `get_object_taxonomies ` does. 

 If a post type has multiple taxonomies, `wp-breadcrumbs` choose an arbitrary one (the first). I added a filter so we can choose a primary one. 

Let me know if some changes are needed.
