### PR TITLE
fix inc2734_wp_breadcrumbs_remove_last_link filter

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -132,7 +132,7 @@ class Bootstrap {
 		$remove_link = apply_filters( 'inc2734_wp_breadcrumbs_remove_last_link', true );
 		foreach ( $this->breadcrumbs as $k => $item ) {
 			if ( count( $this->breadcrumbs ) === $k + 1 && $remove_link ) {
-				unset( $item['link'] );
+				unset( $this->breadcrumbs[$k]['link'] );
 			}
 		}
 		return apply_filters( 'inc2734_wp_breadcrumbs', $this->breadcrumbs );


### PR DESCRIPTION
初めまして。
`inc2734_wp_breadcrumbs_remove_last_link`フィルターが`true`になっていてもリンクが削除されなかったため、修正してプルリクさせてください。
`$this->breadcrumbs`を直接触ったので、問題あればリジェクトしてください🙇